### PR TITLE
Add optional tree caching to speed up checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbac2",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Simple RBAC checker with support for context checks.",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,20 @@ Paths are checked in serial order. The shortest path is picked up first (though 
 found, any remaining paths are not checked and the result is returned
 immediately.
 
+### Caching of rule trees
+If you have a large/complex set of rules with roles inheriting from other roles, generating the tree for the role can take a significant amount of time (tens of milliseconds). To speed up the checks, you can ask rbac to cache the tree for each role once it has been generated, at the expense of slightly more use of memory to hold the cached trees.
+
+To use in-memory caching of the trees, instantiate RBAC with an optional third parameter, cacheTrees, or set it after creating the object. It defaults to false, unless set.
+
+```js
+var RBAC = require('rbac2', false, true);
+```
+or
+```js
+var RBAC = require('rbac2');
+RBAC.cacheTrees = true;
+```
+
 ## Testing
 Install dev dependencies and run:
 ```bash

--- a/tests/index.js
+++ b/tests/index.js
@@ -19,9 +19,49 @@ var rules = [
     {a: 'user'           , can: 'read articles'}
 ];
 
-var rbac = new RBAC(rules);
-
 describe('RBAC', function () {
+    var rbac = new RBAC(rules);
+
+    describe('check', function () {
+        it('should work with no-condition paths', function (done) {
+            rbac.check('admin', 'read articles', function (err, res) {
+                if (err) {
+                    throw err;
+                }
+                assert.ok(res);
+                done();
+            });
+        });
+
+        it('should work with conditional functions - fail case', function (done) {
+            rbac.check('user', 'edit article', function (err, res) {
+                if (err) {
+                    throw err;
+                }
+
+                assert.ok(!res);
+                done();
+            });
+        });
+
+        it('should work with conditional functions - pass case', function (done) {
+            rbac.check('user', 'edit article', {
+                userId: 2
+            }, function (err, res) {
+                if (err) {
+                    throw err;
+                }
+
+                assert.ok(res);
+                done();
+            });
+        });
+    });
+});
+
+describe('RBAC with caching', function () {
+    var rbac = new RBAC(rules, false, true);
+
     describe('check', function () {
         it('should work with no-condition paths', function (done) {
             rbac.check('admin', 'read articles', function (err, res) {


### PR DESCRIPTION
I found that rbac checks in my project were taking a significant amount of time. It turns out that because we have quite lengthy & complex rulesets with inherited roles, building the tree of activities for each role was taking a significant amount of time. With the addition of some simple in-memory caching, that time is reduced to nothing, and the other parts of the check are very fast (~1ms) already.

I updated the tests and the README to test and explain the added functionality.